### PR TITLE
Beanstalkd driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ install:
     - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
 
 script:
-    - composer test
+    - composer test -- --env travis
     - composer check-quality

--- a/codeception.yml
+++ b/codeception.yml
@@ -13,3 +13,6 @@ coverage:
     enabled: true
     include:
         - src/*
+env:
+    beanstalkd:
+    travis:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "jms/serializer": "^3.0",
     "symfony/yaml": "^4.0",
     "predis/predis": "^1.1",
-    "aws/aws-sdk-php": "^3.99"
+    "aws/aws-sdk-php": "^3.99",
+    "pda/pheanstalk": "^4.0"
   },
   "scripts": {
     "test": [

--- a/src/Driver/BeanstalkdQueue.php
+++ b/src/Driver/BeanstalkdQueue.php
@@ -1,0 +1,165 @@
+<?php declare(strict_types=1);
+
+namespace Initx\Driver;
+
+use Initx\Envelope;
+use Initx\Exception\IllegalStateException;
+use Initx\Exception\NoSuchElementException;
+use Initx\Queue;
+use JMS\Serializer\SerializerInterface;
+use Pheanstalk\Contract\PheanstalkInterface;
+
+/**
+ * Class BeanstalkdQueue
+ *
+ * @package Initx\Driver
+ */
+final class BeanstalkdQueue implements Queue
+{
+    use HasFallbackSerializer;
+
+    /**
+     * @var PheanstalkInterface
+     */
+    private $client;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var string
+     */
+    private $queueName;
+
+    /**
+     * BeanstalkdQueue constructor.
+     *
+     * @param PheanstalkInterface      $client
+     * @param string                   $queueName
+     * @param SerializerInterface|null $serializer
+     */
+    public function __construct(
+        PheanstalkInterface $client,
+        string $queueName = PheanstalkInterface::DEFAULT_TUBE,
+        ?SerializerInterface $serializer = null
+    ) {
+        $this->client = $client;
+        $this->queueName = $queueName;
+        $this->serializer = $this->fallbackSerializer($serializer);
+    }
+
+    /**
+     * Inserts an element if possible, otherwise throwing exception.
+     *
+     * @param Envelope $envelope
+     * @return bool
+     * @throws IllegalStateException
+     */
+    public function add(Envelope $envelope): bool
+    {
+        if (!$this->offer($envelope)) {
+            throw new IllegalStateException('Could not write to redis');
+        }
+
+        return true;
+    }
+
+    /**
+     * Inserts an element if possible, otherwise returning false.
+     *
+     * @param Envelope $envelope
+     * @return bool
+     */
+    public function offer(Envelope $envelope): bool
+    {
+        $serialized = $this->serializer->serialize($envelope, 'json');
+
+        return (bool)$this->client
+            ->useTube($this->queueName)
+            ->put($serialized);
+    }
+
+    /**
+     * Remove and return head of queue, otherwise throwing exception.
+     *
+     * @return Envelope
+     * @throws NoSuchElementException
+     */
+    public function remove(): Envelope
+    {
+        $element = $this->poll();
+
+        if (!$element) {
+            throw new NoSuchElementException();
+        }
+
+        return $element;
+    }
+
+    /**
+     * Remove and return head of queue, otherwise returning null.
+     *
+     * @return Envelope | null
+     */
+    public function poll(): ?Envelope
+    {
+        $job = $this->client
+            ->watch($this->queueName)
+            ->reserveWithTimeout(0);
+
+        if (empty($job)) {
+            return null;
+        }
+
+        $serialized = $job->getData();
+
+        if (empty($serialized)) {
+            return null;
+        }
+
+        return $this->serializer->deserialize($serialized, Envelope::class, 'json');
+    }
+
+    /**
+     * Return but do not remove head of queue, otherwise throwing exception.
+     *
+     * @return Envelope
+     * @throws NoSuchElementException
+     */
+    public function element(): Envelope
+    {
+        $element = $this->peek();
+
+        if (!$element) {
+            throw new NoSuchElementException();
+        }
+
+        return $element;
+    }
+
+    /**
+     * Return but do not remove head of queue, otherwise returning null.
+     *
+     * @return Envelope | null
+     */
+    public function peek(): ?Envelope
+    {
+        $job = $this->client
+            ->watch($this->queueName)
+            ->peekReady();
+
+        if (empty($job)) {
+            return null;
+        }
+
+        $serialized = $job->getData();
+
+        if (empty($serialized)) {
+            return null;
+        }
+
+        return $this->serializer->deserialize($serialized, Envelope::class, 'json');
+    }
+}

--- a/src/Driver/HasFallbackSerializer.php
+++ b/src/Driver/HasFallbackSerializer.php
@@ -7,7 +7,7 @@ use JMS\Serializer\SerializerInterface;
 
 trait HasFallbackSerializer
 {
-    public function fallbackSerializer(?SerializerInterface $serializer = null): SerializerInterface
+    private function fallbackSerializer(?SerializerInterface $serializer = null): SerializerInterface
     {
         if (!$serializer) {
             $separator = DIRECTORY_SEPARATOR;

--- a/tests/_support/Double/BeanstalkdClientMother.php
+++ b/tests/_support/Double/BeanstalkdClientMother.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Double;
+
+use Pheanstalk\Contract\PheanstalkInterface;
+use Pheanstalk\Pheanstalk;
+
+class BeanstalkdClientMother
+{
+    public static function default(): PheanstalkInterface
+    {
+        return Pheanstalk::create(
+            (string)getenv('BEANSTALKD_HOST') ?: '127.0.0.1',
+            (int)getenv('BEANSTALKD_PORT') ?: PheanstalkInterface::DEFAULT_PORT,
+            (int)getenv('BEANSTALKD_TIMEOUT') ?: 10
+        );
+    }
+}

--- a/tests/_support/InteractsWithBeanstalkd.php
+++ b/tests/_support/InteractsWithBeanstalkd.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests;
+
+use Initx\Driver\HasFallbackSerializer;
+use Initx\Envelope;
+use JMS\Serializer\SerializerInterface;
+use Pheanstalk\Contract\PheanstalkInterface;
+use Throwable;
+
+trait InteractsWithBeanstalkd
+{
+    use HasFallbackSerializer;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    public function __construct()
+    {
+        $this->serializer = $this->fallbackSerializer(null);
+    }
+
+    /**
+     * Clear the entire tube.
+     *
+     * @param PheanstalkInterface $pheanstalk
+     */
+    private function clearTube(PheanstalkInterface $pheanstalk)
+    {
+        try {
+            while ($job = $pheanstalk->peekReady()) {
+                $pheanstalk->delete($job);
+            }
+        } catch (Throwable $e) {
+        }
+    }
+
+    /**
+     * Assert that the queue has a specific amount of ready messages.
+     *
+     * @param IntegrationTester   $I
+     * @param PheanstalkInterface $pheanstalk
+     * @param int                 $count
+     */
+    private function seeQueueHasCurrentCount(IntegrationTester $I, PheanstalkInterface $pheanstalk, int $count)
+    {
+        $stats = $pheanstalk->statsTube(PheanstalkInterface::DEFAULT_TUBE);
+
+        $I->assertEquals($count, (int)$stats['current-jobs-ready']);
+    }
+
+    /**
+     * Assert what the current ready message is.
+     *
+     * @param IntegrationTester   $I
+     * @param PheanstalkInterface $pheanstalk
+     * @param Envelope            $envelope
+     */
+    private function seeCurrentJobIs(IntegrationTester $I, PheanstalkInterface $pheanstalk, Envelope $envelope)
+    {
+        $ready = $pheanstalk->peekReady();
+
+        $serialized = $this->serializer->serialize($envelope, 'json');
+
+        $I->assertEquals($serialized, $ready->getData());
+    }
+}

--- a/tests/integration/Driver/BeanstalkdQueueCest.php
+++ b/tests/integration/Driver/BeanstalkdQueueCest.php
@@ -1,0 +1,169 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Integration\Driver;
+
+use Initx\Driver\BeanstalkdQueue;
+use Pheanstalk\Contract\PheanstalkInterface;
+use Tests\Double\EnvelopeMother;
+use Tests\Double\BeanstalkdClientMother;
+use Tests\IntegrationTester;
+use Tests\InteractsWithBeanstalkd;
+
+/**
+ * Class BeanstalkdQueueCest
+ *
+ * @package Tests\Integration\Driver
+ */
+class BeanstalkdQueueCest
+{
+    use InteractsWithBeanstalkd;
+
+    /**
+     * @param IntegrationTester $I
+     */
+    public function _before(IntegrationTester $I): void
+    {
+        $this->clearTube(BeanstalkdClientMother::default());
+    }
+
+    /**
+     * @param IntegrationTester $I
+     *
+     * @throws \Initx\Exception\IllegalStateException
+     * @env beanstalkd
+     */
+    public function add(IntegrationTester $I): void
+    {
+        $envelope = EnvelopeMother::any();
+        $pheanstalk = BeanstalkdClientMother::default();
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $actual = $queue->add($envelope);
+
+        $this->seeQueueHasCurrentCount($I, $pheanstalk, 1);
+        $this->seeCurrentJobIs($I, $pheanstalk, $envelope);
+        $I->assertTrue($actual);
+    }
+
+    /**
+     * @param IntegrationTester $I
+     * @env beanstalkd
+     */
+    public function offer(IntegrationTester $I): void
+    {
+        $envelope = EnvelopeMother::any();
+        $pheanstalk = BeanstalkdClientMother::default();
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $queue->offer($envelope);
+
+        $this->seeQueueHasCurrentCount($I, $pheanstalk, 1);
+        $this->seeCurrentJobIs($I, $pheanstalk, $envelope);
+    }
+
+    /**
+     * @param IntegrationTester $I
+     *
+     * @throws \Initx\Exception\IllegalStateException
+     * @throws \Initx\Exception\NoSuchElementException
+     * @env beanstalkd
+     */
+    public function remove(IntegrationTester $I): void
+    {
+        $pheanstalk = BeanstalkdClientMother::default();
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $envelopeOne = EnvelopeMother::any();
+        $envelopeTwo = EnvelopeMother::any();
+
+        $queue->add($envelopeOne);
+        $queue->add($envelopeTwo);
+
+        $actualOne = $queue->remove();
+        $actualTwo = $queue->remove();
+
+        $I->assertEquals($envelopeOne, $actualOne);
+        $I->assertEquals($envelopeTwo, $actualTwo);
+        $this->seeQueueHasCurrentCount($I, $pheanstalk, 0);
+    }
+
+    /**
+     * @param IntegrationTester $I
+     *
+     * @throws \Initx\Exception\IllegalStateException
+     * @env beanstalkd
+     */
+    public function poll(IntegrationTester $I): void
+    {
+        $pheanstalk = BeanstalkdClientMother::default();
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $envelopeOne = EnvelopeMother::any();
+        $envelopeTwo = EnvelopeMother::any();
+
+        $queue->add($envelopeOne);
+        $queue->add($envelopeTwo);
+
+        $actualOne = $queue->poll();
+        $actualTwo = $queue->poll();
+        $actualThree = $queue->poll();
+
+        $I->assertEquals($envelopeOne, $actualOne);
+        $I->assertEquals($envelopeTwo, $actualTwo);
+        $I->assertNull($actualThree);
+        $this->seeQueueHasCurrentCount($I, $pheanstalk, 0);
+    }
+
+    /**
+     * @param IntegrationTester $I
+     *
+     * @throws \Initx\Exception\IllegalStateException
+     * @env beanstalkd
+     */
+    public function peek(IntegrationTester $I): void
+    {
+        $pheanstalk = BeanstalkdClientMother::default();
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $envelopeOne = EnvelopeMother::any();
+        $envelopeTwo = EnvelopeMother::any();
+
+        $queue->add($envelopeOne);
+        $queue->add($envelopeTwo);
+
+        $actualOne = $queue->peek();
+        $actualTwo = $queue->peek();
+
+        $I->assertEquals($envelopeOne, $actualOne);
+        // actual two = envelope one
+        $I->assertEquals($envelopeOne, $actualTwo);
+        $this->seeQueueHasCurrentCount($I, $pheanstalk, 2);
+    }
+
+    /**
+     * @param IntegrationTester $I
+     *
+     * @throws \Initx\Exception\IllegalStateException
+     * @throws \Initx\Exception\NoSuchElementException
+     * @env beanstalkd
+     */
+    public function element(IntegrationTester $I): void
+    {
+        $pheanstalk = BeanstalkdClientMother::default();
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $envelopeOne = EnvelopeMother::any();
+        $envelopeTwo = EnvelopeMother::any();
+
+        $queue->add($envelopeOne);
+        $queue->add($envelopeTwo);
+
+        $actualOne = $queue->element();
+        $actualTwo = $queue->element();
+
+        $I->assertEquals($envelopeOne, $actualOne);
+        // actual two = envelope one
+        $I->assertEquals($envelopeOne, $actualTwo);
+        $this->seeQueueHasCurrentCount($I, $pheanstalk, 2);
+    }
+}

--- a/tests/unit/Driver/BeanstalkdQueueCest.php
+++ b/tests/unit/Driver/BeanstalkdQueueCest.php
@@ -1,0 +1,307 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Driver;
+
+use Initx\Driver\BeanstalkdQueue;
+use Initx\Driver\HasFallbackSerializer;
+use Mockery;
+use Mockery\Mock;
+use Pheanstalk\Contract\PheanstalkInterface;
+use Pheanstalk\Job;
+use Tests\Double\EnvelopeMother;
+use Tests\Double\BeanstalkdClientMother;
+use Tests\IntegrationTester;
+use Tests\InteractsWithBeanstalkd;
+
+/**
+ * Class BeanstalkdQueueCest
+ *
+ * @package Tests\Integration\Driver
+ */
+class BeanstalkdQueueCest
+{
+    use HasFallbackSerializer;
+
+    /**
+     * @var \JMS\Serializer\SerializerInterface
+     */
+    private $serializer;
+
+    public function __construct()
+    {
+        $this->serializer = $this->fallbackSerializer();
+    }
+
+    /**
+     * @param IntegrationTester $I
+     *
+     * @throws \Initx\Exception\IllegalStateException
+     */
+    public function add(IntegrationTester $I): void
+    {
+        $envelope = EnvelopeMother::any();
+        $serialized = $this->serializer->serialize($envelope, 'json');
+
+        $pheanstalk = Mockery::mock(PheanstalkInterface::class);
+        $pheanstalk->expects()
+                   ->useTube(PheanstalkInterface::DEFAULT_TUBE)
+                   ->once()
+                   ->andReturnSelf();
+
+        $pheanstalk->expects()
+            ->put($serialized)
+            ->once()
+            ->andReturn(Mockery::mock(Job::class));
+
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+
+        $actual = $queue->add($envelope);
+
+        $I->assertTrue($actual);
+    }
+
+    /**
+     * @param IntegrationTester $I
+     */
+    public function offer(IntegrationTester $I): void
+    {
+        $envelope = EnvelopeMother::any();
+        $serialized = $this->serializer->serialize($envelope, 'json');
+
+        $pheanstalk = Mockery::mock(PheanstalkInterface::class);
+        $pheanstalk->expects()
+                   ->useTube(PheanstalkInterface::DEFAULT_TUBE)
+                   ->once()
+                   ->andReturnSelf();
+
+        $pheanstalk->expects()
+                   ->put(Mockery::any())
+                   ->once()
+                   ->andReturn(Mockery::mock(Job::class));
+
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $envelope = EnvelopeMother::any();
+
+        $queue->offer($envelope);
+    }
+
+    /**
+     * @param IntegrationTester $I
+     *
+     * @throws \Initx\Exception\IllegalStateException
+     * @throws \Initx\Exception\NoSuchElementException
+     */
+    public function remove(IntegrationTester $I): void
+    {
+        $envelopeOne = EnvelopeMother::any();
+        $envelopeTwo = EnvelopeMother::any();
+
+        $serializedOne = $this->serializer->serialize($envelopeOne, 'json');
+        $serializedTwo = $this->serializer->serialize($envelopeTwo, 'json');
+
+        $pheanstalk = Mockery::mock(PheanstalkInterface::class);
+        $pheanstalk->expects()
+                   ->useTube(PheanstalkInterface::DEFAULT_TUBE)
+                   ->twice()
+                   ->andReturnSelf();
+
+        $pheanstalk->expects()
+                   ->watch(PheanstalkInterface::DEFAULT_TUBE)
+                   ->twice()
+                   ->andReturnSelf();
+
+        $pheanstalk->shouldReceive('reserveWithTimeout')
+                   ->with(0)
+                   ->twice()
+                   ->andReturn(
+                       Mockery::mock(Job::class)
+                              ->shouldReceive('getData')
+                              ->andReturn($serializedOne)
+                              ->getMock(),
+                       Mockery::mock(Job::class)
+                              ->shouldReceive('getData')
+                              ->andReturn($serializedTwo)
+                              ->getMock()
+                   );
+
+        $pheanstalk->shouldReceive('put')
+                   ->with(Mockery::any())
+                   ->twice()
+                   ->andReturn(Mockery::mock(Job::class));
+
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $queue->add($envelopeOne);
+        $queue->add($envelopeTwo);
+
+        $actualOne = $queue->remove();
+        $actualTwo = $queue->remove();
+
+        $I->assertEquals($envelopeOne, $actualOne);
+        $I->assertEquals($envelopeTwo, $actualTwo);
+    }
+
+    public function poll(IntegrationTester $I)
+    {
+        $envelopeOne = EnvelopeMother::any();
+        $envelopeTwo = EnvelopeMother::any();
+
+        $serializedOne = $this->serializer->serialize($envelopeOne, 'json');
+        $serializedTwo = $this->serializer->serialize($envelopeTwo, 'json');
+
+        $pheanstalk = Mockery::mock(PheanstalkInterface::class);
+        $pheanstalk->expects()
+                   ->useTube(PheanstalkInterface::DEFAULT_TUBE)
+                   ->times(3)
+                   ->andReturnSelf();
+
+        $pheanstalk->expects()
+                   ->watch(PheanstalkInterface::DEFAULT_TUBE)
+                   ->times(3)
+                   ->andReturnSelf();
+
+        $pheanstalk->shouldReceive('reserveWithTimeout')
+                   ->with(0)
+                   ->twice()
+                   ->andReturn(
+                       Mockery::mock(Job::class)
+                              ->shouldReceive('getData')
+                              ->andReturn($serializedOne)
+                              ->getMock(),
+                       Mockery::mock(Job::class)
+                              ->shouldReceive('getData')
+                              ->andReturn($serializedTwo)
+                              ->getMock(),
+                       null
+                   );
+
+        $pheanstalk->shouldReceive('put')
+                   ->with(Mockery::any())
+                   ->times(3)
+                   ->andReturn(Mockery::mock(Job::class));
+
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $queue->add($envelopeOne);
+        $queue->add($envelopeTwo);
+
+        $actualOne = $queue->poll();
+        $actualTwo = $queue->poll();
+        $actualThree = $queue->poll();
+
+        $I->assertEquals($envelopeOne, $actualOne);
+        $I->assertEquals($envelopeTwo, $actualTwo);
+        $I->assertNull($actualThree);
+    }
+
+    /**
+     * @param IntegrationTester $I
+     *
+     * @throws \Initx\Exception\IllegalStateException
+     */
+    public function peek(IntegrationTester $I): void
+    {
+        $envelopeOne = EnvelopeMother::any();
+        $envelopeTwo = EnvelopeMother::any();
+
+        $serializedOne = $this->serializer->serialize($envelopeOne, 'json');
+
+        $pheanstalk = Mockery::mock(PheanstalkInterface::class);
+        $pheanstalk->expects()
+                   ->useTube(PheanstalkInterface::DEFAULT_TUBE)
+                   ->twice()
+                   ->andReturnSelf();
+
+        $pheanstalk->expects()
+                   ->watch(PheanstalkInterface::DEFAULT_TUBE)
+                   ->twice()
+                   ->andReturnSelf();
+
+        $pheanstalk->shouldReceive('peekReady')
+                   ->twice()
+                   ->andReturn(
+                       Mockery::mock(Job::class)
+                              ->shouldReceive('getData')
+                              ->andReturn($serializedOne)
+                              ->getMock(),
+                       Mockery::mock(Job::class)
+                              ->shouldReceive('getData')
+                              ->andReturn($serializedOne)
+                              ->getMock()
+                   );
+
+        $pheanstalk->shouldReceive('put')
+                   ->with(Mockery::any())
+                   ->twice()
+                   ->andReturn(Mockery::mock(Job::class));
+
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $queue->add($envelopeOne);
+        $queue->add($envelopeTwo);
+
+        $actualOne = $queue->peek();
+        $actualTwo = $queue->peek();
+
+        $I->assertEquals($envelopeOne, $actualOne);
+        // actual two = envelope one
+        $I->assertEquals($envelopeOne, $actualTwo);
+    }
+
+    /**
+     * @param IntegrationTester $I
+     *
+     * @throws \Initx\Exception\IllegalStateException
+     * @throws \Initx\Exception\NoSuchElementException
+     */
+    public function element(IntegrationTester $I): void
+    {
+        $envelopeOne = EnvelopeMother::any();
+        $envelopeTwo = EnvelopeMother::any();
+
+        $serializedOne = $this->serializer->serialize($envelopeOne, 'json');
+
+        $pheanstalk = Mockery::mock(PheanstalkInterface::class);
+        $pheanstalk->expects()
+                   ->useTube(PheanstalkInterface::DEFAULT_TUBE)
+                   ->twice()
+                   ->andReturnSelf();
+
+        $pheanstalk->expects()
+                   ->watch(PheanstalkInterface::DEFAULT_TUBE)
+                   ->twice()
+                   ->andReturnSelf();
+
+        $pheanstalk->shouldReceive('peekReady')
+                   ->twice()
+                   ->andReturn(
+                       Mockery::mock(Job::class)
+                              ->shouldReceive('getData')
+                              ->andReturn($serializedOne)
+                              ->getMock(),
+                       Mockery::mock(Job::class)
+                              ->shouldReceive('getData')
+                              ->andReturn($serializedOne)
+                              ->getMock()
+                   );
+
+        $pheanstalk->shouldReceive('put')
+                   ->with(Mockery::any())
+                   ->twice()
+                   ->andReturn(Mockery::mock(Job::class));
+
+        $queue = new BeanstalkdQueue($pheanstalk, PheanstalkInterface::DEFAULT_TUBE);
+
+        $queue->add($envelopeOne);
+        $queue->add($envelopeTwo);
+
+        $actualOne = $queue->element();
+        $actualTwo = $queue->element();
+
+        $I->assertEquals($envelopeOne, $actualOne);
+        // actual two = envelope one
+        $I->assertEquals($envelopeOne, $actualTwo);
+    }
+}


### PR DESCRIPTION
+ Includes unit test
+ Includes integation test

- Changed some things around to make it easier to test beanstalkd integration (like making fallbackSerializer private)
- includes a integration test that is not run in travis because it does not have a beanstalkd service (use --env beanstalkd in an environment with beanstalkd to do a integration test)
- Does not use the codecept queue module because it uses Pheanstalk 3 and it didn't work correctly.